### PR TITLE
enable args without values

### DIFF
--- a/src/Console/ParallelCommand.php
+++ b/src/Console/ParallelCommand.php
@@ -73,7 +73,7 @@ class ParallelCommand extends Command
         ), null, []);
 
         $process->setTimeout(null);
-
+        
         return $process->run(function ($type, $line) {
             if (Process::ERR === $type) {
                 $this->output->writeln("<bg=red;fg=white>$line</>");
@@ -108,9 +108,9 @@ class ParallelCommand extends Command
     protected function paratestArguments($options)
     {
         $options = Arr::where($options, function ($value, $key) {
-            return is_string($value);
+            return is_string($value) || $value == true;
         });
-
+        
         $arguments = $this->buildCommand($options);
 
         if (! file_exists($file = base_path('phpunit.xml'))) {
@@ -135,9 +135,11 @@ class ParallelCommand extends Command
         $arguments = [];
 
         foreach ($options as $flag => $value) {
-            array_push($arguments, "--{$flag}=$value");
+            if($value === true)
+                array_push($arguments, "--{$flag}");
+            else
+                array_push($arguments, "--{$flag}=$value");
         }
-
         return $arguments;
     }
 }

--- a/src/Console/ParallelCommand.php
+++ b/src/Console/ParallelCommand.php
@@ -73,7 +73,7 @@ class ParallelCommand extends Command
         ), null, []);
 
         $process->setTimeout(null);
-        
+
         return $process->run(function ($type, $line) {
             if (Process::ERR === $type) {
                 $this->output->writeln("<bg=red;fg=white>$line</>");
@@ -110,7 +110,7 @@ class ParallelCommand extends Command
         $options = Arr::where($options, function ($value, $key) {
             return is_string($value) || $value == true;
         });
-        
+
         $arguments = $this->buildCommand($options);
 
         if (! file_exists($file = base_path('phpunit.xml'))) {


### PR DESCRIPTION
Arguments without values are ignored during building commands
this is a fix to add them while building arguments that are without values 